### PR TITLE
Fix failing selenium tests

### DIFF
--- a/intro/exercise-solutions/quiz-game/part-09/src/test/java/org/tsdes/intro/exercises/quizgame/po/IndexPO.java
+++ b/intro/exercise-solutions/quiz-game/part-09/src/test/java/org/tsdes/intro/exercises/quizgame/po/IndexPO.java
@@ -14,7 +14,7 @@ public class IndexPO extends PageObject {
     }
 
     public void toStartingPage(){
-        getDriver().get(host + ":" + port);
+        toOrigin();
     }
 
     @Override

--- a/intro/exercise-solutions/quiz-game/part-10/src/test/java/org/tsdes/intro/exercises/quizgame/selenium/po/IndexPO.java
+++ b/intro/exercise-solutions/quiz-game/part-10/src/test/java/org/tsdes/intro/exercises/quizgame/selenium/po/IndexPO.java
@@ -18,7 +18,7 @@ public class IndexPO extends LayoutPO {
     }
 
     public void toStartingPage(){
-        getDriver().get(host + ":" + port);
+        toOrigin();
     }
 
     @Override

--- a/intro/exercise-solutions/quiz-game/part-11/frontend/src/test/java/org/tsdes/intro/exercises/quizgame/selenium/PageObject.java
+++ b/intro/exercise-solutions/quiz-game/part-11/frontend/src/test/java/org/tsdes/intro/exercises/quizgame/selenium/PageObject.java
@@ -48,6 +48,10 @@ public abstract class PageObject {
         return port;
     }
 
+    public void toOrigin() {
+        driver.get("http://" + host + ":" + port);
+    }
+
     public void refresh(){
         driver.navigate().refresh();
     }

--- a/intro/exercise-solutions/quiz-game/part-11/frontend/src/test/java/org/tsdes/intro/exercises/quizgame/selenium/po/IndexPO.java
+++ b/intro/exercise-solutions/quiz-game/part-11/frontend/src/test/java/org/tsdes/intro/exercises/quizgame/selenium/po/IndexPO.java
@@ -18,7 +18,7 @@ public class IndexPO extends LayoutPO {
     }
 
     public void toStartingPage(){
-        getDriver().get(host + ":" + port);
+        toOrigin();
     }
 
     @Override

--- a/intro/jee/jsf/examples/src/main/java/org/tsdes/intro/jee/jsf/examples/ex06/NavigationBean.java
+++ b/intro/jee/jsf/examples/src/main/java/org/tsdes/intro/jee/jsf/examples/ex06/NavigationBean.java
@@ -1,6 +1,5 @@
 package org.tsdes.intro.jee.jsf.examples.ex06;
 
-
 import org.tsdes.intro.jee.jsf.examples.ex04.SessionCounter;
 
 import javax.enterprise.context.RequestScoped;

--- a/intro/jee/jsf/examples/src/main/webapp/WEB-INF/web.xml
+++ b/intro/jee/jsf/examples/src/main/webapp/WEB-INF/web.xml
@@ -15,7 +15,7 @@
     responsible to receive and process the HTTP requests from the client.
     Here, we are saying the we should start the servlet that is responsible
     to handle JSF (there can be several different kinds of servlets, even
-    custom ones, but we ll see only JSF in this course).
+    custom ones, but we'll see only JSF in this course).
   -->
   <servlet>
     <servlet-name>Faces Servlet</servlet-name>

--- a/intro/spring/bean/configuration/src/test/java/org/tsdes/intro/spring/bean/configuration/service/MyServiceTestNot.java
+++ b/intro/spring/bean/configuration/src/test/java/org/tsdes/intro/spring/bean/configuration/service/MyServiceTestNot.java
@@ -9,7 +9,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Created by arcuri82 on 26-Jan-18.
  */
-@ExtendWith(SpringExtension.class)@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
 public class MyServiceTestNot {
 
     /*

--- a/intro/spring/bean/profile/src/main/resources/application.properties
+++ b/intro/spring/bean/profile/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 # https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
 #
 # Properties can be set in a "application.properties" file, or also in YML format in a
-# "application.yml" format. Usually, YML is preferred as more compact, less verbose.
+# "application.yml" format. Usually, YAML is preferred as more compact, less verbose.
 
 # Properties for Database, eg where it can be found and which drivers to use.
 # Note: as this is an example, and not a production-level application, here we just

--- a/intro/spring/bean/profile/src/test/java/org/tsdes/intro/spring/bean/profile/PostgresDockerTest.java
+++ b/intro/spring/bean/profile/src/test/java/org/tsdes/intro/spring/bean/profile/PostgresDockerTest.java
@@ -25,10 +25,10 @@ import org.tsdes.intro.spring.bean.jpa.Application;
  * Created by arcuri82 on 26-Jan-18.
  */
 @ActiveProfiles("docker") //activate profile, load configs from application-docker.yml
-@ContextConfiguration(initializers = PostgresDocketTest.DockerInitializer.class)
+@ContextConfiguration(initializers = PostgresDockerTest.DockerInitializer.class)
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Application.class)
-public class PostgresDocketTest extends DbTestBase {
+public class PostgresDockerTest extends DbTestBase {
 
     /*
         Following rule would start Postgres inside Docker, and expose the

--- a/intro/spring/jsf/pom.xml
+++ b/intro/spring/jsf/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>javax.servlet.jsp.jstl-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/intro/spring/security/framework/src/test/java/org/tsdes/intro/spring/security/framework/selenium/po/IndexPO.java
+++ b/intro/spring/security/framework/src/test/java/org/tsdes/intro/spring/security/framework/selenium/po/IndexPO.java
@@ -24,7 +24,7 @@ public class IndexPO extends PageObject {
     }
 
     public void toStartingPage() {
-        getDriver().get(host + ":" + port);
+        toOrigin();
         waitForPageToLoad();
     }
 

--- a/intro/spring/security/manual/src/test/java/org/tsdes/intro/spring/security/manual/selenium/po/IndexPO.java
+++ b/intro/spring/security/manual/src/test/java/org/tsdes/intro/spring/security/manual/selenium/po/IndexPO.java
@@ -23,7 +23,7 @@ public class IndexPO extends PageObject {
     }
 
     public void toStartingPage() {
-        getDriver().get(host+":"+port);
+        getDriver().get("http://"+host+":"+port);
         waitForPageToLoad();
         doLogout();
     }

--- a/intro/spring/security/manual/src/test/java/org/tsdes/intro/spring/security/manual/selenium/po/IndexPO.java
+++ b/intro/spring/security/manual/src/test/java/org/tsdes/intro/spring/security/manual/selenium/po/IndexPO.java
@@ -23,7 +23,7 @@ public class IndexPO extends PageObject {
     }
 
     public void toStartingPage() {
-        getDriver().get("http://"+host+":"+port);
+        toOrigin();
         waitForPageToLoad();
         doLogout();
     }

--- a/intro/spring/testing/coverage/jacoco/frontend/src/test/java/org/tsdes/intro/spring/testing/coverage/jacoco/frontend/HomePageObject.java
+++ b/intro/spring/testing/coverage/jacoco/frontend/src/test/java/org/tsdes/intro/spring/testing/coverage/jacoco/frontend/HomePageObject.java
@@ -1,8 +1,6 @@
 package org.tsdes.intro.spring.testing.coverage.jacoco.frontend;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.tsdes.misc.testutils.selenium.PageObject;
 
 public class HomePageObject extends PageObject {
@@ -19,13 +17,12 @@ public class HomePageObject extends PageObject {
 
 
     public void toStartingPage(){
-        getDriver().get("http://" + host + ":" + port);
+        toOrigin();
         waitForPageToLoad();
     }
 
 
     public void changeData(String value){
-
         setText("form:text", value);
         clickAndWait("form:modify");
     }

--- a/intro/spring/testing/coverage/jacoco/frontend/src/test/java/org/tsdes/intro/spring/testing/coverage/jacoco/frontend/HomePageObject.java
+++ b/intro/spring/testing/coverage/jacoco/frontend/src/test/java/org/tsdes/intro/spring/testing/coverage/jacoco/frontend/HomePageObject.java
@@ -19,7 +19,7 @@ public class HomePageObject extends PageObject {
 
 
     public void toStartingPage(){
-        getDriver().get(host + ":" + port);
+        getDriver().get("http://" + host + ":" + port);
         waitForPageToLoad();
     }
 

--- a/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/selenium/po/HomePO.java
+++ b/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/selenium/po/HomePO.java
@@ -19,7 +19,7 @@ public class HomePO extends PageObject{
     }
 
     public void toStartingPage(){
-        driver.get("http://" + host + ":" + port);
+        toOrigin();
     }
 
     @Override

--- a/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/selenium/po/HomePO.java
+++ b/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/selenium/po/HomePO.java
@@ -19,7 +19,7 @@ public class HomePO extends PageObject{
     }
 
     public void toStartingPage(){
-        driver.get(host + ":" + port);
+        driver.get("http://" + host + ":" + port);
     }
 
     @Override

--- a/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/service/DeleterService.java
+++ b/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/service/DeleterService.java
@@ -34,7 +34,7 @@ public class DeleterService {
         /*
             Note: we passed as input a Class<?> instead of a String to
             avoid SQL injection. However, being here just test code, it should
-            not be a problem. But, as a good habit, always be paranoiac about
+            not be a problem. But, as a good habit, always be paranoid about
             security, above all when you have code that can delete the whole
             database...
          */

--- a/misc/test-utils/src/main/java/org/tsdes/misc/testutils/selenium/PageObject.java
+++ b/misc/test-utils/src/main/java/org/tsdes/misc/testutils/selenium/PageObject.java
@@ -44,6 +44,10 @@ public abstract class PageObject {
         return port;
     }
 
+    public void toOrigin() {
+        driver.get("http://" + host + ":" + port);
+    }
+
     public void refresh(){
         driver.navigate().refresh();
     }


### PR DESCRIPTION
Not specifying the protocol when calling `driver.get(…)` on a URL caused the action to fail (i.e. not successfully retrieve the web page) on my machine. Fixed by explicitly specifying protocol `http://`.