### PR TITLE
Fix GitCrawler

### DIFF
--- a/intro/spring/security/framework/src/main/java/org/tsdes/intro/spring/security/framework/WebSecurityConfig.java
+++ b/intro/spring/security/framework/src/main/java/org/tsdes/intro/spring/security/framework/WebSecurityConfig.java
@@ -59,7 +59,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             /*
                 Authorization rules are checked 1 at a time, starting from the top.
                 Matching is based on the resource path in the HTTP request, and can
-                user regex for it.
+                use a regex for it.
                 We want to allow anyone to access the homepage and the login/signup/logout.
                 All other pages are denied unless the user is authenticated.
                 Note: login and logout pages are handled specially by Spring Security.

--- a/intro/spring/security/manual/src/test/java/org/tsdes/intro/spring/security/manual/http/HttpTest.java
+++ b/intro/spring/security/manual/src/test/java/org/tsdes/intro/spring/security/manual/http/HttpTest.java
@@ -47,7 +47,7 @@ public class HttpTest {
                 "Host:localhost\r\n" +
                 "\r\n";
 
-        //do one request with no cookie: we ll get asked by server to set one
+        //do one request with no cookie: we'll get asked by server to set one
         String a = HttpUtils.executeHttpCommand("localhost", port, httpGet);
         assertTrue(a.contains("200"));
         assertTrue(a.contains("Set-Cookie"));

--- a/intro/spring/testing/selenium/crawler/src/main/java/org/tsdes/intro/jee/jsf/crawler/GitCrawler.java
+++ b/intro/spring/testing/selenium/crawler/src/main/java/org/tsdes/intro/jee/jsf/crawler/GitCrawler.java
@@ -153,11 +153,11 @@ public class GitCrawler {
                     - build files might not be in root folder
                     - no check if there was any error in the loaded page
                  */
-                List<WebElement> maven = driver.findElements(By.xpath("//td[contains(@class,'content')]//a[@title='pom.xml']"));
+                List<WebElement> maven = driver.findElements(By.xpath("//div[contains(@class,'Details')]//a[@title='pom.xml']"));
                 if (!maven.isEmpty()) {
                     System.out.println("" + name + " uses Maven");
                 } else {
-                    List<WebElement> gradle =  driver.findElements(By.xpath("//td[contains(@class,'content')]//a[@title='build.gradle']"));
+                    List<WebElement> gradle =  driver.findElements(By.xpath("//div[contains(@class,'Details')]//a[@title='build.gradle']"));
                     if (!gradle.isEmpty()) {
                         System.out.println("" + name + " uses Gradle");
                     } else {

--- a/intro/spring/testing/selenium/crawler/src/main/java/org/tsdes/intro/jee/jsf/crawler/GitCrawler.java
+++ b/intro/spring/testing/selenium/crawler/src/main/java/org/tsdes/intro/jee/jsf/crawler/GitCrawler.java
@@ -161,7 +161,7 @@ public class GitCrawler {
                     if (!gradle.isEmpty()) {
                         System.out.println("" + name + " uses Gradle");
                     } else {
-                        System.out.println("" + name + " undefined build system");
+                        System.out.println("" + name + " uses unrecognized/no build system");
                     }
                 }
             }

--- a/intro/spring/testing/selenium/crawler/src/main/java/org/tsdes/intro/jee/jsf/crawler/GitCrawler.java
+++ b/intro/spring/testing/selenium/crawler/src/main/java/org/tsdes/intro/jee/jsf/crawler/GitCrawler.java
@@ -173,7 +173,7 @@ public class GitCrawler {
             */
             sleep(6000);
 
-            driver.get(current);
+            driver.navigate().back();
             waitForPageToLoad(driver);
 
             sleep(6000);

--- a/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/selenium/SeleniumDockerIT.java
+++ b/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/selenium/SeleniumDockerIT.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.GenericContainer;

--- a/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/service/CommentServiceTest.java
+++ b/intro/spring/testing/selenium/jsf-tests/src/test/java/org/tsdes/intro/spring/testing/selenium/jsftests/service/CommentServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.tsdes.intro.spring.jsf.Application;
 import org.tsdes.intro.spring.jsf.ex03.Comment;
 import org.tsdes.intro.spring.jsf.ex03.CommentService;


### PR DESCRIPTION
Updates GitCrawler XPath expressions so it works with updated Github layout. Also replaces re-search of same page with navigation back in history instead, as these searches often return different results for the same search (presumably due to the sheer volume of potential search hits).