### PR TITLE
Fix crashing deployment module

### DIFF
--- a/intro/spring/deployment/pom.xml
+++ b/intro/spring/deployment/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/intro/spring/flyway/src/main/java/org/tsdes/intro/spring/flyway/Application.java
+++ b/intro/spring/flyway/src/main/java/org/tsdes/intro/spring/flyway/Application.java
@@ -1,6 +1,5 @@
 package org.tsdes.intro.spring.flyway;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication


### PR DESCRIPTION
To avoid the app crashing with the following error
```
2021-04-15T10:52:15.409437+00:00 app[web.1]: Caused by: java.lang.ClassNotFoundException: javax.xml.bind.JAXBException
```